### PR TITLE
Reformatted index.html "correctly"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,22 +3,22 @@
 <html lang="en">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="author" content="Thomas Coleman <tom@ilikeprograms.com>">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="author" content="Thomas Coleman <tom@ilikeprograms.com>">
 
-    <title>Bootstrap Theme Editor</title>
+  <title>Bootstrap Theme Editor</title>
 
   <link type="text/css" href="build/less/bootstrap.less" rel="stylesheet/less" />
   <link type="text/css" href="src/example.css" rel="stylesheet" />
   <link type="text/css" href="bower_components/font-awesome/css/font-awesome.min.css" rel="stylesheet" /> 
 
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-      <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
-    <![endif]-->
+  <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+  <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+    <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+  <![endif]-->
   <style id="holderjs-style" type="text/css"></style>
 </head>
 


### PR DESCRIPTION
Something was playing up with the formatting in `index.html`. I converted tabs to spaces and indented 2 spaces out.

You could barely read the HTML before, and most of it was off the screen. Should be okay now.

Nice script.
